### PR TITLE
Fix XTR utils for Matlab R2016a

### DIFF
--- a/src/loading-utils/rnx-nav/getNavigationHeader.m
+++ b/src/loading-utils/rnx-nav/getNavigationHeader.m
@@ -23,18 +23,21 @@ function [hdr, endOfHeaderIndex] = getNavigationHeader(raw)
 
 % Parsing header
 lineIndex = 0;
+hdr.version = [];
 while 1
     lineIndex = lineIndex + 1;
     line = raw{lineIndex};
     
     % Get version information
-    if contains(line,'RINEX VERSION / TYPE')
+    if contains(line,'RINEX VERSION / TYPE') && isempty(hdr.version)
         hdr.version = round(str2double(line(1:20)));
     end   
     
     % Get leap seconds information from header
     if contains(line,'LEAP SECONDS')
         hdr.leapSeconds = str2double(line(1:20));
+    else
+        hdr.leapSeconds = [];
     end 
     
     if contains(line,'ION ALPHA')
@@ -53,6 +56,10 @@ while 1
     if contains(line,'END OF HEADER')
         break
     end
+end
+
+if isempty(hdr.version)
+    error('Not possible to resolve navigation RINEX file version!');
 end
 
 % Assign endOfHeaderIndex variable

--- a/src/loading-utils/rnx-obs/OBSRNX.m
+++ b/src/loading-utils/rnx-obs/OBSRNX.m
@@ -144,7 +144,7 @@ classdef OBSRNX
                 localRefPoint = obj.recpos;
                 satList = obj.sat.(s);
                 satFlags = obj.satTimeFlags.(s);
-                obj.satpos(i) = SATPOS(s,satList,ephType,ephFolder,obj.t(:,7:8),localRefPoint,satFlags);
+                obj.satpos(i) = SATPOS(s,satList,ephType,ephFolder,obj.t(:,7:8),localRefPoint,satFlags,obj.header.leapSeconds);
             end
             
             % Consistency checks

--- a/src/loading-utils/rnx-obs/OBSRNX.m
+++ b/src/loading-utils/rnx-obs/OBSRNX.m
@@ -501,20 +501,22 @@ classdef OBSRNX
     end
     methods 
         % Plotting functions
-        function skyplot = makeSkyplot(obj,gnsses,backgroundFile,transparency)
+        function skyplot = makeSkyplot(obj,gnsses,showSatNames,backgroundFile,transparency)
             if isempty(obj.satpos)
                 error('ValidationError:SatellitePostionsNotAvailable',...
                     'First satellite position needs to be computed using "OBSRNX.computeSatPosition" method!');
             end
             
-            if nargin < 4
+            if nargin < 5
                transparency = 50;
-               if nargin < 3
+               if nargin < 4
                   skyplotClassFolder = fileparts(which('Skyplot'));
                   backgroundFile = fullfile(skyplotClassFolder,'sampleSkyplot.png');
-                  if nargin < 2
-                      gnsses = arrayfun(@(x) x.gnss,obj.satpos);
-                     
+                  if nargin < 3
+                      showSatNames = false;
+                      if nargin < 2
+                         gnsses = arrayfun(@(x) x.gnss,obj.satpos);
+                      end
                   end
                end
             end
@@ -529,13 +531,15 @@ classdef OBSRNX
                 for j = 1:length(obj.satpos(i).satList)
                     satNo = obj.satpos(i).satList(j);
                     satStr = sprintf('%s%02d',obj.satpos(i).gnss,satNo);
-                    [elev,azi] = obj.getLocal(obj.satpos(i).gnss,satNo,obj.satpos(i).satTimeFlags(:,j));
+                    [elev,azi] = obj.getLocal(obj.satpos(i).gnss,satNo); %,obj.satpos(i).satTimeFlags(:,j)
                     isValid = elev ~= 0 & azi ~= 0;
                     elev(~isValid) = nan;
                     azi(~isValid) = nan;
                     skyplot = skyplot.addPlot(elev,azi,satStr,'-',cols(i,:));
-                    [xText,yText] = Skyplot.getCartFromPolar(skyplot.R,elev(end),azi(end));
-                    text(xText,yText,satStr,'Color',cols(i,:));
+                    if showSatNames
+                       [xText,yText] = Skyplot.getCartFromPolar(skyplot.R,elev(end),azi(end));
+                       text(xText,yText,satStr,'Color',cols(i,:));
+                    end
                 end
             end
             
@@ -693,6 +697,10 @@ classdef OBSRNX
                     satsNo = [satsNo,satNo];
                     satsIn = [satsIn,in];
                 end
+            end
+            
+            if ~isempty(satsIn)
+                satsIn = logical(satsIn);
             end
         end
 

--- a/src/other/Skyplot.m
+++ b/src/other/Skyplot.m
@@ -4,8 +4,6 @@ classdef Skyplot < handle
         labels = {}
         lgd
         cb
-    end
-    properties (Access = private)
         R
     end
     methods
@@ -27,7 +25,7 @@ classdef Skyplot < handle
             set(obj.fig,'Units','centimeters');
             set(obj.fig,'PaperUnits','centimeters');
             set(obj.fig,'PaperPositionMode','Auto');
-            hold on
+            hold on;
             pos = get(obj.fig,'Position');
             set(obj.fig,'PaperSize',[pos(3),pos(4)])
             
@@ -37,7 +35,7 @@ classdef Skyplot < handle
             % Showing figure
             f = imshow(img,'InitialMagnification','fit');
             set(f,'AlphaData',alpha);
-            axis equal off
+            axis equal off;
             
             % Determine fisheye panorama diameter from image size
             obj.R = mean([size(img,1),size(img,2)])/2;
@@ -185,6 +183,13 @@ classdef Skyplot < handle
                     obj.cb.Position = [0.185 0.05 0.54 0.03];
                 end
             end
+        end
+    end
+    methods (Static)
+        function [x,y] = getCartFromPolar(R,elev,azi)
+            r = ((90 - elev)/90)*R;
+            x = R + r.*sind(azi);
+            y = R - r.*cosd(azi);
         end
     end
 end

--- a/src/other/Skyplot.m
+++ b/src/other/Skyplot.m
@@ -127,21 +127,27 @@ classdef Skyplot < handle
             xRegion = []; yRegion = [];
             pointsInBetween = 20;
             for i = 1:length(regionElevation)-1
+                if regionAzimuth(i) == regionAzimuth(i+1)
+                    azimuthRange = repmat(regionAzimuth(i),[1,pointsInBetween]);
+                else
+                    dAzi = regionAzimuth(i+1)-regionAzimuth(i);
+                    if dAzi < -180
+                        regionAzimuth(i) = regionAzimuth(i)-360;
+                    end
+                    azimuthRange = linspace(regionAzimuth(i),regionAzimuth(i+1),pointsInBetween);
+                end
                 if regionElevation(i) == regionElevation(i+1)
                     elevationRange = repmat(regionElevation(i),[1,pointsInBetween]);
                 else
                     elevationRange = linspace(regionElevation(i),regionElevation(i+1),pointsInBetween);
                 end
-                if regionAzimuth(i) == regionAzimuth(i+1)
-                    azimuthRange = repmat(regionAzimuth(i),[1,pointsInBetween]);
-                else
-                    azimuthRange = linspace(regionAzimuth(i),regionAzimuth(i+1),pointsInBetween);
-                end
+                [xRegionPoints,yRegionPoints] = obj.polar2cart(regionElevation,regionAzimuth);
                 [x,y] = obj.polar2cart(elevationRange,azimuthRange);
                 xRegion = [xRegion, x];
                 yRegion = [yRegion, y];
             end
             set(0,'CurrentFigure',obj.fig);
+            %plot(xRegionPoints,yRegionPoints,'r.','HandleVisibility','off');
             patch('XData',xRegion,'YData',yRegion,'FaceColor',color,'FaceAlpha',transparency(1),...
                 'EdgeAlpha',transparency(2),'LineStyle',lineStyle,'HandleVisibility','off');
         end

--- a/src/other/Skyplot.m
+++ b/src/other/Skyplot.m
@@ -110,6 +110,41 @@ classdef Skyplot < handle
             scatter(x,y,markerSize,vals,'filled','MarkerFaceAlpha',.5,'MarkerEdgeAlpha',.5,'HandleVisibility','off')
             obj.initializeColorbar();
         end
+        function obj = plotRegion(obj,regionElevation,regionAzimuth,color,transparency,lineStyle)
+            validateattributes(regionElevation,{'double'},{'size',[1,nan]},2);
+            validateattributes(regionAzimuth,{'double'},{'size',[1,nan]},3);
+            if nargin < 6
+                lineStyle = '-';
+                if nargin < 5
+                    transparency = [0.2, 0.2]; % [FaceAlpha, EdgeAlpha]
+                    if nargin < 4
+                        color = 'red';
+                    end
+                end
+            end
+            
+            % Interpolate to spherical coordinates
+            xRegion = []; yRegion = [];
+            pointsInBetween = 20;
+            for i = 1:length(regionElevation)-1
+                if regionElevation(i) == regionElevation(i+1)
+                    elevationRange = repmat(regionElevation(i),[1,pointsInBetween]);
+                else
+                    elevationRange = linspace(regionElevation(i),regionElevation(i+1),pointsInBetween);
+                end
+                if regionAzimuth(i) == regionAzimuth(i+1)
+                    azimuthRange = repmat(regionAzimuth(i),[1,pointsInBetween]);
+                else
+                    azimuthRange = linspace(regionAzimuth(i),regionAzimuth(i+1),pointsInBetween);
+                end
+                [x,y] = obj.polar2cart(elevationRange,azimuthRange);
+                xRegion = [xRegion, x];
+                yRegion = [yRegion, y];
+            end
+            set(0,'CurrentFigure',obj.fig);
+            patch('XData',xRegion,'YData',yRegion,'FaceColor',color,'FaceAlpha',transparency(1),...
+                'EdgeAlpha',transparency(2),'LineStyle',lineStyle,'HandleVisibility','off');
+        end
         function obj = adjustColorbarLimits(obj,limits)
             if ~isempty(obj.cb)
                 set(obj.cb,'Limits',limits)

--- a/src/other/cartesianToGeodetic.m
+++ b/src/other/cartesianToGeodetic.m
@@ -1,0 +1,55 @@
+function [fi,la,h] = cartesianToGeodetic(X,Y,Z,ellipsoidData,angleUnits)
+validateattributes(X,{'double'},{'size',[nan,1]},1);
+validateattributes(Y,{'double'},{'size',[nan,1]},2);
+validateattributes(Z,{'double'},{'size',[nan,1]},3);
+validateattributes(ellipsoidData,{'double'},{'size',[1,2]},4);
+
+if nargin < 5
+    angleUnits = 'radians';
+end
+
+switch angleUnits
+    case 'radians'
+        isDegrees = false;
+    case 'degrees'
+        isDegrees = true;
+    otherwise
+        error('Unknown option "%s"! Only strings "radians" and "degrees" are allowed!',units);
+end
+
+% Unpack ellipsoid constants (major axis and eccentricity)
+aEllipsoid = ellipsoidData(1);
+eEllipsoid = ellipsoidData(2);
+
+la = atan2(Y,X);
+la(la < 0) = la(la < 0) + 2*pi;
+p = sqrt(X.^2 + Y.^2);
+
+% Get initial value of fi
+fi = atan2(Z./p,1-eEllipsoid^2);
+h = zeros(size(fi));
+
+% Formula for osculating radius
+N = @(a,e,phi) a./sqrt(1-(e*sin(phi)).^2);
+diff_fi = 1;
+diff_h = 1;
+
+while true
+    fiPrevious = fi;
+    hPrevious = h;
+    Ni = N(aEllipsoid,eEllipsoid,fi);
+    h = p./cos(fi) - Ni;
+    fi = atan2(Z./p,1-(Ni/(Ni+h))*eEllipsoid^2);
+    diff_fi = max(abs(fi - fiPrevious));
+    diff_h = max(abs(h - hPrevious));
+    
+    if diff_fi < 1.4544e-10 && diff_h < 0.001
+        break
+    end
+end
+
+% Conversion to degrees if required
+if isDegrees
+    la = rad2deg(la);
+    fi = rad2deg(fi);
+end

--- a/src/other/cartesianToLocalVertical.m
+++ b/src/other/cartesianToLocalVertical.m
@@ -1,0 +1,50 @@
+function [de,dn,du] = cartesianToLocalVertical(X,Y,Z,fi0,la0,h0,ellipsoidData,angleUnits)
+validateattributes(X,{'double'},{'size',[nan,1]},1);
+validateattributes(Y,{'double'},{'size',[nan,1]},2);
+validateattributes(Z,{'double'},{'size',[nan,1]},3);
+validateattributes(fi0,{'double'},{'size',[1,1]},4);
+validateattributes(la0,{'double'},{'size',[1,1]},5);
+validateattributes(h0,{'double'},{'size',[1,1]},6);
+validateattributes(ellipsoidData,{'double'},{'size',[1,2]},4);
+
+if nargin < 8
+    angleUnits = 'degrees';
+end
+
+switch angleUnits
+    case 'radians'
+        isDegrees = false;
+    case 'degrees'
+        isDegrees = true;
+    otherwise
+        error('Unknown option "%s"! Only strings "radians" and "degrees" are allowed!',units);
+end
+
+% Unpack ellipsoid constants (major axis and eccentricity)
+aEllipsoid = ellipsoidData(1);
+eEllipsoid = ellipsoidData(2);
+
+if isDegrees
+    fi0 = deg2rad(fi0);
+    la0 = deg2rad(la0);
+end
+N0 = aEllipsoid/sqrt(1-(eEllipsoid*sin(fi0)).^2);
+X0 = (N0 + h0)*cos(fi0)*cos(la0);
+Y0 = (N0 + h0)*cos(fi0)*sin(la0);
+Z0 = ((1-eEllipsoid^2)*N0 + h0)*sin(fi0);
+
+% Definition of rotation to local system
+R(1,:) = [         -sin(la0),               cos(la0),              0];
+R(2,:) = [-cos(la0)*sin(fi0),     -sin(la0)*sin(fi0),       cos(fi0)];
+R(3,:) = [ cos(la0)*cos(fi0),      sin(la0)*cos(fi0),       sin(fi0)];
+
+for i = 1:length(X)
+    dXYZ = [X(i);Y(i);Z(i)] - [X0;Y0;Z0];
+    dENU(:,i) = R*dXYZ;
+end
+dENU = dENU';
+
+de = dENU(:,1);
+dn = dENU(:,2);
+du = dENU(:,3);
+

--- a/src/processing/CorrectionMap.m
+++ b/src/processing/CorrectionMap.m
@@ -66,7 +66,8 @@ classdef CorrectionMap
             
             % Replace nan by 0 (only for plotting purposes)
             corrForPlotting = 1e3*obj.corr;
-            corrForPlotting(isnan(corrForPlotting)) = 1000;
+            %corrForPlotting(isnan(corrForPlotting)) = 1000; % Nan regions are red
+            corrForPlotting(isnan(corrForPlotting)) = 0;     % Nan regions are white
             
             f = figure();
             plotTitle = sprintf('Correction grid (%s, %s)',obj.gnss,obj.obsType);

--- a/src/xtr-utils/getDefaultXTRoptions.m
+++ b/src/xtr-utils/getDefaultXTRoptions.m
@@ -23,7 +23,7 @@ end
 
 % Validation
 validateattributes(plotType,{'char'},{},1)
-mustBeMember(plotType,{'MP','SNR','CS'})
+assert(ismember(plotType,{'MP','SNR','CS'}),'Input "plotType" has to be one of: MP, SNR, CS!');
 
 % General options
 opt = struct(...

--- a/src/xtr-utils/lib/dataCell2CSmatrix.m
+++ b/src/xtr-utils/lib/dataCell2CSmatrix.m
@@ -1,6 +1,8 @@
 function [timeStamp, CSprns, CScell] = dataCell2CSmatrix(dataCell)
 
-timeStamp = cellfun(@(c) datetime(c(9:27),'InputFormat','yyyy-MM-dd HH:mm:ss'), dataCell);
+for i = 1:length(dataCell)
+    timeStamp(i,1) = datetime(dataCell{i}(9:27),'InputFormat','yyyy-MM-dd HH:mm:ss');
+end
 CSprns = cell2mat(cellfun(@(c) str2num(c(31:32)), dataCell, 'UniformOutput', 0));
 
 CScell = cell(1,32);

--- a/src/xtr-utils/lib/dataCell2matrix.m
+++ b/src/xtr-utils/lib/dataCell2matrix.m
@@ -1,7 +1,9 @@
 function [timeStamp, meanVal, dataMatrix] = dataCell2matrix(dataCell)
 
-timeStamp = cellfun(@(c) datetime(c(9:27),'InputFormat','yyyy-MM-dd HH:mm:ss'), dataCell);
-data = cell2mat(cellfun(@(c) str2num(strrep([c(28:end),' '],'- ','0 ')), dataCell, 'UniformOutput', 0));
+for i = 1:length(dataCell)
+    timeStamp(i,1) = datetime(dataCell{i}(9:27),'InputFormat','yyyy-MM-dd HH:mm:ss');
+end
+data = cell2mat(cellfun(@(c) str2num(strrep([c(28:end),' '],'- ','0 ')),dataCell,'UniformOutput',false));
 data(data == 0) = nan;
 meanVal = data(:,1);
 dataMatrix = data(:,2:end);

--- a/src/xtr-utils/lib/gaussian.m
+++ b/src/xtr-utils/lib/gaussian.m
@@ -1,0 +1,4 @@
+function h = gaussian(m,n,sigma)
+[h1, h2] = meshgrid(-(m-1)/2:(m-1)/2, -(n-1)/2:(n-1)/2);
+hg = exp(-(h1.^2+h2.^2)/(2*sigma^2));
+h = hg./sum(hg(:));

--- a/src/xtr-utils/lib/getNoSatZone.m
+++ b/src/xtr-utils/lib/getNoSatZone.m
@@ -18,7 +18,12 @@ function [x_edge,y_edge] = getNoSatZone(GNSS,pos)
 deg = pi/180;
 DELTA = (0:1:359)*deg;
 R = 6378137;
-[phi0,~,h0] = ecef2geodetic(pos(1),pos(2),pos(3),[R, sqrt(0.00669438002290)]);
+try
+    % If geodetic toolbox available
+    [phi0,~,h0] = ecef2geodetic(pos(1),pos(2),pos(3),[R,sqrt(0.00669438002290)]);
+catch
+    [phi0,~,h0] = cartesianToGeodetic(pos(1),pos(2),pos(3),[R,sqrt(0.00669438002290)]);
+end
 lam0 = 0;
 
 switch GNSS
@@ -41,8 +46,12 @@ end
 X_sat = a.*cos(INC).*cos(DELTA);
 Y_sat = a.*cos(INC).*sin(DELTA);
 Z_sat = ones(1,length(X_sat)).*a.*sin(INC);
-[e,n,u] = ecef2lv(X_sat,Y_sat,Z_sat, phi0, lam0, h0, [R, sqrt(0.00669438002290)]);
-
+try
+    % If geodetic toolbox available
+    [e,n,u] = ecef2enu(X_sat,Y_sat,Z_sat, phi0, lam0, h0, [R, sqrt(0.00669438002290)],'radians');
+catch
+    [e,n,u] = cartesianToLocalVertical(X_sat',Y_sat',Z_sat', phi0, lam0, h0, [R, sqrt(0.00669438002290)],'radians');
+end
 zenit = 90 - atan(u./sqrt(n.^2 + e.^2))/deg;
 azimuth = atan2(e,n)*180/pi;
 azimuth(azimuth<0) = azimuth(azimuth<0) + 360;

--- a/src/xtr-utils/xtr2CSskyplot.m
+++ b/src/xtr-utils/xtr2CSskyplot.m
@@ -120,6 +120,12 @@ for i = 1:length(GNScell)
     allGNSSSatPos.azi = [allGNSSSatPos.azi; AZI.(GNScell{i}).vals];
     allGNSSSatPos.ele = [allGNSSSatPos.ele; ELE.(GNScell{i}).vals];
 end
+
+% Check if SNR struct exist (if not then input file not contain required data)
+if ~exist('CS','var')
+    error('Input XTR file "%s" does not contain Cycleslip information!');
+end
+
 allGNSSSatPos.azi = allGNSSSatPos.azi(:);
 allGNSSSatPos.ele = allGNSSSatPos.ele(:);
 selNotNan = ~isnan(allGNSSSatPos.azi) & ~isnan(allGNSSSatPos.ele);

--- a/src/xtr-utils/xtr2CSskyplot.m
+++ b/src/xtr-utils/xtr2CSskyplot.m
@@ -178,7 +178,12 @@ end
 
 % Kernel smoothing (empirical parameter)
 empParam = 0.685;
-gaussKernel = fspecial('gaussian',binSize+[1,1],1.5);
+try
+    % Require Matlab image processing toolbox
+    gaussKernel = fspecial('gaussian',binSize+[1,1],1.5);
+catch
+    gaussKernel = gaussian(binSize(1)+1,binSize(2)+1,1.5);
+end
 Nsmt = conv2(N,gaussKernel,'same');
 Nsmt = empParam^2*conv2(Nsmt,ones(binSize+[1,1]),'same');
 %maxSlipsInBinSmt = max(max(Nsmt));

--- a/src/xtr-utils/xtr2MPskyplot.m
+++ b/src/xtr-utils/xtr2MPskyplot.m
@@ -146,6 +146,13 @@ for i = 1:length(GNScell)
     MP.(GNScell{i}).vector = MP.(GNScell{i}).vals(sel);
 end
 
+% Check if MP struct exist (if not then input file not contain required data)
+if exist('MP','var')
+    out.MP = MP;
+else
+    error('Input XTR file "%s" does not contain Multipath information!');
+end
+
 % Put output together
 out.AZI = AZI;
 out.ELE = ELE;

--- a/src/xtr-utils/xtr2SNRskyplot.m
+++ b/src/xtr-utils/xtr2SNRskyplot.m
@@ -136,11 +136,12 @@ end
 % Put output together
 out.AZI = AZI;
 out.ELE = ELE;
+
+% Check if SNR struct exist (if not then input file not contain required data)
 if exist('SNR','var')
     out.SNR = SNR;
 else
-    warning('No SNR data available for specified %s!',SNRcode)
-    return 
+    error('Input XTR file "%s" does not contain SNR information!');
 end
 
 allGNSSSatPos.azi = allGNSSSatPos.azi(:);

--- a/test/loading-utils/rnx-obs/OBSRNXtest.m
+++ b/test/loading-utils/rnx-obs/OBSRNXtest.m
@@ -240,9 +240,9 @@ classdef OBSRNXtest < matlab.unittest.TestCase
             %skyplot3.exportToFile('c:\Users\petos\Documents\ST3_PhD\xxx.png','png',300)
         end
         function testMakeLocalSelection(obj)
-            %o = obj.obsrnx.computeSatPosition('broadcast','../../data/brdc');
+            o = obj.obsrnx.computeSatPosition('broadcast','../../data/brdc');
             %o.saveToMAT(fullfile(pwd(),'testOut.mat'));
-            o = OBSRNX.loadFromMAT(fullfile(pwd(),'testOut.mat'));
+            %o = OBSRNX.loadFromMAT(fullfile(pwd(),'testOut.mat'));
             skyplot = o.makeSkyplot('G');
             regionElevation = [10 50 50 10 10];
             regionAzimuth = [90 90 180 180 90];

--- a/test/loading-utils/rnx-obs/OBSRNXtest.m
+++ b/test/loading-utils/rnx-obs/OBSRNXtest.m
@@ -230,9 +230,9 @@ classdef OBSRNXtest < matlab.unittest.TestCase
             backgroundFile = fullfile(pwd(),'../../other/skyplotTestBackground.png');
             transparency = 85;
             gnssSelection = 'GR';
-            %o = obj.obsrnx.computeSatPosition('broadcast','../../data/brdc');
+            o = obj.obsrnx.computeSatPosition('broadcast','../../data/brdc');
             %o.saveToMAT(fullfile(pwd(),'testOut.mat'));
-            o = OBSRNX.loadFromMAT(fullfile(pwd(),'testOut.mat'));
+            %o = OBSRNX.loadFromMAT(fullfile(pwd(),'testOut.mat'));
             skyplot1 = o.makeSkyplot(); legend off;
             skyplot2 = o.makeSkyplot(gnssSelection); legend off;
             skyplot3 = o.makeSkyplot(gnssSelection,backgroundFile); legend off;

--- a/test/loading-utils/rnx-obs/OBSRNXtest.m
+++ b/test/loading-utils/rnx-obs/OBSRNXtest.m
@@ -227,7 +227,7 @@ classdef OBSRNXtest < matlab.unittest.TestCase
             obj.obsrnxqi.exportToFile(fullfile(pwd(),'testOutWithQualityIndicators.rnx'));
         end
         function testMakeSkyplot(obj)
-            backgroundFile = fullfile(pwd(),'../../other/skyplotTestBackground.png');
+            backgroundFile = fullfile('../../other/skyplotTestBackground.png');
             transparency = 85;
             gnssSelection = 'GR';
             o = obj.obsrnx.computeSatPosition('broadcast','../../data/brdc');
@@ -235,9 +235,15 @@ classdef OBSRNXtest < matlab.unittest.TestCase
             %o = OBSRNX.loadFromMAT(fullfile(pwd(),'testOut.mat'));
             skyplot1 = o.makeSkyplot(); legend off;
             skyplot2 = o.makeSkyplot(gnssSelection); legend off;
-            skyplot3 = o.makeSkyplot(gnssSelection,backgroundFile); legend off;
-            skyplot4 = o.makeSkyplot(gnssSelection,backgroundFile,transparency); legend off;
-            %skyplot3.exportToFile('c:\Users\petos\Documents\ST3_PhD\xxx.png','png',300)
+            skyplot3 = o.makeSkyplot(gnssSelection,true); legend off;
+            skyplot4 = o.makeSkyplot(gnssSelection,true,backgroundFile); legend off;
+            skyplot5 = o.makeSkyplot(gnssSelection,true,backgroundFile,transparency); legend off;
+            
+            %skyplot1.exportToFile(fullfile(pwd(),'skyplot1.png'),'png',300)
+            %skyplot2.exportToFile(fullfile(pwd(),'skyplot2.png'),'png',300)
+            %skyplot3.exportToFile(fullfile(pwd(),'skyplot3.png'),'png',300)
+            %skyplot4.exportToFile(fullfile(pwd(),'skyplot4.png'),'png',300)
+            %skyplot5.exportToFile(fullfile(pwd(),'skyplot5.png'),'png',300)
         end
         function testMakeRegionSelection(obj)
             o = obj.obsrnx.computeSatPosition('broadcast','../../data/brdc');

--- a/test/loading-utils/rnx-obs/OBSRNXtest.m
+++ b/test/loading-utils/rnx-obs/OBSRNXtest.m
@@ -1,6 +1,7 @@
 classdef OBSRNXtest < matlab.unittest.TestCase
     properties
         obsrnx
+        obsrnxSatpos
         obsrnxqi
         antex
     end
@@ -76,6 +77,11 @@ classdef OBSRNXtest < matlab.unittest.TestCase
             obj.verifyEqual(oldRecPos(1)+dH*cosd(lat)*cosd(lon),obj.obsrnx.recpos(1),'Abstol',1e-10);
             obj.verifyEqual(oldRecPos(2)+dH*cosd(lat)*sind(lon),obj.obsrnx.recpos(2),'Abstol',1e-10);
             obj.verifyEqual(oldRecPos(3)+dH*sind(lat),obj.obsrnx.recpos(3),'Abstol',1e-10);
+        end
+        function testMakeSkyplotAssert(obj)
+            % Method 'makeSkyplot' should raise assertion if 'satpos' element is empty
+            % (no satellite positions are available)
+            obj.verifyError(@() obj.obsrnx.makeSkyplot(),'ValidationError:SatellitePostionsNotAvailable')
         end
         function testComputeBrdc(obj)
             obj.obsrnx = obj.obsrnx.computeSatPosition('broadcast','../../data/brdc');
@@ -219,6 +225,19 @@ classdef OBSRNXtest < matlab.unittest.TestCase
             obj.obsrnx.exportToFile(fullfile(pwd(),'testOut.rnx'),gnsses,decimate,false);
             obj.obsrnx.exportToFile(fullfile(pwd(),'testOutWithOffsets.rnx'),gnsses,decimate,writeReceiverOffset);
             obj.obsrnxqi.exportToFile(fullfile(pwd(),'testOutWithQualityIndicators.rnx'));
+        end
+        function testMakeSkyplot(obj)
+            backgroundFile = fullfile(pwd(),'../../other/skyplotTestBackground.png');
+            transparency = 85;
+            gnssSelection = 'GR';
+            %o = obj.obsrnx.computeSatPosition('broadcast','../../data/brdc');
+            %o.saveToMAT(fullfile(pwd(),'testOut.mat'));
+            o = OBSRNX.loadFromMAT(fullfile(pwd(),'testOut.mat'));
+            skyplot1 = o.makeSkyplot(); legend off;
+            skyplot2 = o.makeSkyplot(gnssSelection); legend off;
+            skyplot3 = o.makeSkyplot(gnssSelection,backgroundFile); legend off;
+            skyplot4 = o.makeSkyplot(gnssSelection,backgroundFile,transparency); legend off;
+            %skyplot3.exportToFile('c:\Users\petos\Documents\ST3_PhD\xxx.png','png',300)
         end
     end
     methods (Test, ParameterCombination='sequential')

--- a/test/loading-utils/rnx-obs/OBSRNXtest.m
+++ b/test/loading-utils/rnx-obs/OBSRNXtest.m
@@ -239,14 +239,14 @@ classdef OBSRNXtest < matlab.unittest.TestCase
             skyplot4 = o.makeSkyplot(gnssSelection,backgroundFile,transparency); legend off;
             %skyplot3.exportToFile('c:\Users\petos\Documents\ST3_PhD\xxx.png','png',300)
         end
-        function testMakeLocalSelection(obj)
+        function testMakeRegionSelection(obj)
             o = obj.obsrnx.computeSatPosition('broadcast','../../data/brdc');
             %o.saveToMAT(fullfile(pwd(),'testOut.mat'));
             %o = OBSRNX.loadFromMAT(fullfile(pwd(),'testOut.mat'));
             skyplot = o.makeSkyplot('G');
             regionElevation = [10 50 50 10 10];
             regionAzimuth = [90 90 180 180 90];
-            %skyplot = skyplot.plotRegion(regionElevation,regionAzimuth);
+            skyplot = skyplot.plotRegion(regionElevation,regionAzimuth);
             [satsNo,~] = o.getSatsInRegion('G',regionElevation,regionAzimuth);
             obj.assertEqual(satsNo,[2,6,13]);
         end

--- a/test/loading-utils/rnx-obs/OBSRNXtest.m
+++ b/test/loading-utils/rnx-obs/OBSRNXtest.m
@@ -239,6 +239,17 @@ classdef OBSRNXtest < matlab.unittest.TestCase
             skyplot4 = o.makeSkyplot(gnssSelection,backgroundFile,transparency); legend off;
             %skyplot3.exportToFile('c:\Users\petos\Documents\ST3_PhD\xxx.png','png',300)
         end
+        function testMakeLocalSelection(obj)
+            %o = obj.obsrnx.computeSatPosition('broadcast','../../data/brdc');
+            %o.saveToMAT(fullfile(pwd(),'testOut.mat'));
+            o = OBSRNX.loadFromMAT(fullfile(pwd(),'testOut.mat'));
+            skyplot = o.makeSkyplot('G');
+            regionElevation = [10 50 50 10 10];
+            regionAzimuth = [90 90 180 180 90];
+            %skyplot = skyplot.plotRegion(regionElevation,regionAzimuth);
+            [satsNo,~] = o.getSatsInRegion('G',regionElevation,regionAzimuth);
+            obj.assertEqual(satsNo,[2,6,13]);
+        end
     end
     methods (Test, ParameterCombination='sequential')
         function testGetObservation(obj,ts)

--- a/test/other/SkyplotTest.m
+++ b/test/other/SkyplotTest.m
@@ -52,5 +52,15 @@ classdef SkyplotTest < matlab.unittest.TestCase
             sp.exportToFile('sample4','pdf');
             sp.exportToFile('sample4','png');
         end
+        function testSkyplotPlotRegion(obj)
+            regionElevation = [10 50 50 10 10];
+            regionAzimuth = [90 90 120 120 90];
+            sp = Skyplot();
+            sp.plotRegion(regionElevation,regionAzimuth);
+            sp.plotRegion(regionElevation+5,regionAzimuth+35,'blue');
+            sp.plotRegion([30 90 90 30 30],[0 0 60 60 0],'cyan');
+            sp.plotRegion(regionElevation+10,regionAzimuth+70,'yellow',[0.8,1]);
+            sp.plotRegion(regionElevation+15,regionAzimuth+105,[0,0.5,0],[0.5,0.8],'--');
+        end
     end
 end

--- a/test/xtr-utils/TestXTRutils.m
+++ b/test/xtr-utils/TestXTRutils.m
@@ -1,0 +1,23 @@
+classdef TestXTRutils < matlab.unittest.TestCase
+    methods (TestClassSetup)
+        function setupTest(obj)
+            addpath(genpath('../../src'))
+        end
+    end
+    methods (TestMethodTeardown)
+        function closeFigures(obj)
+            close all
+        end
+    end
+    methods (Test)
+        function test_xtr2MPskyplotTestBasic(obj)
+            xtr2MPskyplot('../../example/xtr-utils/GANP.xtr','C1C')
+        end
+        function test_xtr2SNRskyplotTestBasic(obj)
+            xtr2SNRskyplot('../../example/xtr-utils/GANP.xtr','S1C')
+        end
+        function test_xtr2CSskyplotTestBasic(obj)
+            xtr2CSskyplot('../../example/xtr-utils/GANP.xtr',true)
+        end
+    end
+end


### PR DESCRIPTION
This MR fix XTR utility functions (xtr2MPskyplot,xtr2SNRskyplot and xtr2CSskyplot) to be run for R2016a. Calls to geodetic and image processing toolbox were replaced by native Matlab code.